### PR TITLE
Add project structure.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+node_modules/
+lib/
+coverage/
+tmp/
+build/
+.idea/
+*~
+*.bak
+*.log
+.*.swp
+.*.swo
+*.kdev4
+*kate-swp
+.arcconfig
+.project

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,8 @@
+# Authors ordered by first contribution.
+
+Lauri Paimen <lauri@paimen.info>
+Anton Kreuzkamp <akreuzkamp@web.de>
+Сковорода Никита Андреевич <chalkerx@gmail.com>
+Michael Martin Moro <michael@unetresgrossebite.com>
+Pavel Vasev <pavel.vasev@gmail.com>
+Henrik Rudstrøm <hrudstrom@gmail.com>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,35 @@
+QmlWeb parser is based on UglifyJS parser, and is distributed under
+the BSD-2-Clause license, as follows:
+
+"""
+Copyright (c) 2010 Mihai Bazon <mihai.bazon@gmail.com>
+Copyright (c) 2011 Lauri Paimen <lauri@paimen.info>
+Copyright (c) 2013 Anton Kreuzkamp <akreuzkamp@web.de>
+Based on parse-js (http://marijn.haverbeke.nl/parse-js/).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above
+    copyright notice, this list of conditions and the following
+    disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials
+    provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER “AS IS” AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+"""

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,47 @@
+const gulp = require('gulp');
+const concat = require('gulp-concat');
+const rename = require('gulp-rename');
+const changed = require('gulp-changed');
+const order = require('gulp-order');
+const uglify = require('gulp-uglify');
+const sourcemaps = require('gulp-sourcemaps');
+const iife = require('gulp-iife');
+
+const sources = [
+  'src/**/*.js'
+];
+
+gulp.task('build-dev', function() {
+  return gulp.src(sources)
+             .pipe(order(sources, { base: __dirname }))
+             .pipe(sourcemaps.init())
+             .pipe(concat('qmlweb.parser.js'))
+             .pipe(iife({
+               useStrict: false,
+               params: ['exports'],
+               args: ['typeof exports !== \'undefined\' ? exports : window']
+             }))
+             .pipe(changed('./lib'))
+             .pipe(sourcemaps.write('./'))
+             .pipe(gulp.dest('./lib'));
+});
+
+gulp.task('build', ['build-dev'], function() {
+  return gulp.src('./lib/qmlweb.parser.js')
+             .pipe(rename('qmlweb.parser.min.js'))
+             .pipe(changed('./lib'))
+             .pipe(sourcemaps.init({ loadMaps: true }))
+             .pipe(uglify())
+             .pipe(sourcemaps.write('./'))
+             .pipe(gulp.dest('./lib'));
+});
+
+gulp.task('watch', ['build'], function() {
+  gulp.watch(sources, ['build']);
+});
+
+gulp.task('watch-dev', ['build-dev'], function() {
+  gulp.watch(sources, ['build-dev']);
+});
+
+gulp.task('default', ['watch']);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "qmlweb-parser",
+  "version": "0.0.0",
+  "description": "QML parser in JavaScript",
+  "license": "BSD-2-Clause",
+  "repository": "qmlweb/qmlweb-parser",
+  "devDependencies": {
+    "gulp": "^3.6.2",
+    "gulp-changed": "^1.3.0",
+    "gulp-concat": "^2.1.7",
+    "gulp-iife": "^0.3.0",
+    "gulp-order": "^1.1.1",
+    "gulp-rename": "^1.2.2",
+    "gulp-replace": "^0.5.4",
+    "gulp-sourcemaps": "^1.6.0",
+    "gulp-uglify": "^1.5.2"
+  },
+  "scripts": {
+    "build": "./node_modules/.bin/gulp build",
+    "watch": "./node_modules/.bin/gulp watch"
+  },
+  "main": "lib/qmlweb.parser.js",
+  "files": [
+    "AUTHORS",
+    "README.md",
+    "lib/**/*.js",
+    "lib/**/*.js.map",
+    "src/**/*.js",
+    "gulpfile.js"
+  ]
+}

--- a/src/parser.js
+++ b/src/parser.js
@@ -1559,6 +1559,4 @@ function HOP(obj, prop) {
 
 var warn = function() {};
 
-if (typeof global != "undefined") {
-  global.qmlweb_parse = qmlweb_parse;
-}
+exports.qmlweb_parse = qmlweb_parse;


### PR DESCRIPTION
Adds AUTHORS, LICENSE, package.json, .gitignore, gulp tasks.

The library is now built to lib/qmlweb.parser.js and minified to
lib/qmlweb.parser.min.js.

Exports are now done through `module.exports` (for Node.js) and though
`window.qmlweb_parse` (for browser, as before).

/cc @qmlweb/collaborators 
I will land this if there would be no comments or objections in 48 hours.

After this gets landed, I plan to cut a 0.0.1 release and make QmlWeb use that.
