### PR TITLE
parser: Support "ModuleQualifier.QMLElement {}" definitions

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1426,6 +1426,10 @@ function qmlweb_parse($TEXT, document_type, exigent_mode, embed_tokens) {
                         next();
                         var subname = S.token.value;
                         next();
+                        /* Check for ModuleQualifier.QMLElement */
+                        if (qml_is_element(subname)) {
+                            return as("qmlelem", propname + "." + subname, undefined, qmlblock());
+                        }
                         expect(":");
                         S.in_function++;
                         var from = S.token.pos,


### PR DESCRIPTION
This is to support using a qualifier such as:

```
import QtQuick 2.0 as Quick

Quick.Item {
}
```
