### PR TITLE
api: Support assigning qualified qmlelem to a property

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -194,8 +194,15 @@ function qmlweb_parse($TEXT, document_type, exigent_mode) {
 
   function maybe_qmlelem(no_in) {
     var expr = maybe_assign(no_in);
-    if (is("punc", "{"))
-      return as("qmlelem", expr[1], undefined, qmlblock());
+    if (is("punc", "{")) {
+      var qmlelem_name;
+      if (expr[0] === "dot") {
+        qmlelem_name = ["dot", expr[1][1], expr[2]];
+      } else {
+        qmlelem_name = expr[1];
+      }
+      return as("qmlelem", qmlelem_name, undefined, qmlblock());
+    }
     return expr;
   }
 

--- a/tests/qml/Properties.qml
+++ b/tests/qml/Properties.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.5
+import QmlWeb.DOM 1.0 as DOM
 
 Rectangle {
   width: 75
@@ -15,4 +16,5 @@ Rectangle {
   property var bar: []
   property Item item: Item {}
   property list<Item> items
+  property var domDiv: DOM.Div {}
 }

--- a/tests/qml/Properties.qml.json
+++ b/tests/qml/Properties.qml.json
@@ -7,6 +7,13 @@
       2.5,
       "",
       true
+    ],
+    [
+      "qmlimport",
+      "QmlWeb.DOM",
+      1,
+      "DOM",
+      true
     ]
   ],
   [
@@ -157,6 +164,25 @@
         "qmlpropdef",
         "items",
         "list"
+      ],
+      [
+        "qmlpropdef",
+        "domDiv",
+        "var",
+        [
+          "stat",
+          [
+            "qmlelem",
+            [
+              "dot",
+              "DOM",
+              "Div"
+            ],
+            null,
+            []
+          ]
+        ],
+        "DOM.Div {}\n"
       ]
     ]
   ]

--- a/tests/tape.js
+++ b/tests/tape.js
@@ -13,6 +13,9 @@ function buildTree(dir, data) {
   data = data || {};
   const subdirs = [];
   for (const file of fs.readdirSync(dir)) {
+    if (file[0] === ".") {
+        continue;
+    }
     const filePath = path.join(dir, file);
     if (fs.lstatSync(filePath).isDirectory()) {
       subdirs.push(filePath);


### PR DESCRIPTION
e.g.

import QtQuick 2.5 as QQ

Repeater {
  delegate: QQ.Rectangle {}
}
