### PR TITLE
qmlweb_parse: support QML pragma statements

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -313,6 +313,13 @@ function qmlweb_parse($TEXT, document_type, exigent_mode) {
     return as("qmlpragma", pragma);
   }
 
+  function qmlpragma() {
+    next();
+    var pragma = S.token.value;
+    next();
+    return as("qmlpragma", pragma);
+  }
+
   function qmlimport() {
     // todo
     next();
@@ -340,13 +347,22 @@ function qmlweb_parse($TEXT, document_type, exigent_mode) {
 
   function qmldocument() {
     var imports = [];
-    while (is("name", "import")) {
-      imports.push(qmlimport());
+    var pragma = [];
+    while (true) {
+      if (is("name", "import")) {
+        imports.push(qmlimport());
+      } else if (is("name", "pragma")) {
+        pragma.push(qmlpragma());
+      } else {
+        break;
+      }
     }
     var root = qmlstatement();
     if (!is("eof"))
       unexpected();
-    return as("toplevel", imports, root);
+    return pragma.length > 0 ?
+      as("toplevel", imports, root, pragma) :
+      as("toplevel", imports, root);
   }
 
   function jsdocument() {

--- a/tests/qml/Pragma.qml
+++ b/tests/qml/Pragma.qml
@@ -1,0 +1,5 @@
+pragma Singleton
+import QtQuick 2.0
+
+Item {
+}

--- a/tests/qml/Pragma.qml.json
+++ b/tests/qml/Pragma.qml.json
@@ -1,0 +1,24 @@
+[
+  "toplevel",
+  [
+    [
+      "qmlimport",
+      "QtQuick",
+      2,
+      "",
+      true
+    ]
+  ],
+  [
+    "qmlelem",
+    "Item",
+    null,
+    []
+  ],
+  [
+    [
+      "qmlpragma",
+      "Singleton"
+    ]
+  ]
+]


### PR DESCRIPTION
Those are added as the third element of the `toplevel` node, for backwards compatibility.

If there are no `pragma` statements, the third element is omitted.

Fixes: https://github.com/qmlweb/qmlweb-parser/issues/27

/cc @machinekoder @stephenmdangelo @akreuzkamp 