### PR TITLE
qmlweb_tokenizer: support mutliline strings in QML mode

### DIFF
--- a/tests/qml/MultilineString.qml
+++ b/tests/qml/MultilineString.qml
@@ -1,0 +1,12 @@
+import QtQuick 2.0
+
+Item {
+  property string foo: "foo\""
+  property string bar: "foo
+                        hello
+                        world
+                       "
+  property string test: '
+  \'
+  '
+}

--- a/tests/qml/MultilineString.qml.json
+++ b/tests/qml/MultilineString.qml.json
@@ -1,0 +1,58 @@
+[
+  "toplevel",
+  [
+    [
+      "qmlimport",
+      "QtQuick",
+      2,
+      "",
+      true
+    ]
+  ],
+  [
+    "qmlelem",
+    "Item",
+    null,
+    [
+      [
+        "qmlpropdef",
+        "foo",
+        "string",
+        [
+          "stat",
+          [
+            "string",
+            "foo\""
+          ]
+        ],
+        "\"foo\\\"\"\n  "
+      ],
+      [
+        "qmlpropdef",
+        "bar",
+        "string",
+        [
+          "stat",
+          [
+            "string",
+            "foo\n                        hello\n                        world\n                       "
+          ]
+        ],
+        "\"foo\n                        hello\n                        world\n                       \"\n  "
+      ],
+      [
+        "qmlpropdef",
+        "test",
+        "string",
+        [
+          "stat",
+          [
+            "string",
+            "\n  '\n  "
+          ]
+        ],
+        "'\n  \\'\n  '\n"
+      ]
+    ]
+  ]
+]


### PR DESCRIPTION
Fixes: https://github.com/qmlweb/qmlweb-parser/issues/29