### PR TITLE
qmlpropdef: support list property types

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -221,6 +221,15 @@ function qmlweb_parse($TEXT, document_type, exigent_mode) {
   function qmlpropdef() {
     var type = S.token.value;
     next();
+
+    var subtype;
+    if (is("operator", "<")) {
+      next();
+      subtype = S.token.value;
+      next();
+      expect_token("operator", ">");
+    }
+
     var name = S.token.value;
     next();
     if (type == "alias") {

--- a/tests/qml/Properties.qml
+++ b/tests/qml/Properties.qml
@@ -14,4 +14,5 @@ Rectangle {
   property var foo: {}
   property var bar: []
   property Item item: Item {}
+  property list<Item> items
 }

--- a/tests/qml/Properties.qml.json
+++ b/tests/qml/Properties.qml.json
@@ -151,7 +151,12 @@
             []
           ]
         ],
-        "Item {}\n"
+        "Item {}\n  "
+      ],
+      [
+        "qmlpropdef",
+        "items",
+        "list"
       ]
     ]
   ]


### PR DESCRIPTION
Fixes: https://github.com/qmlweb/qmlweb-parser/issues/33

Note that `subtype` is not exported to the result yet, hence labeling as «work in progress».

/cc @akreuzkamp, any opinion on how this should be presented in the current output format?

_Long-term, I would prefer to migrate from arrays to objects for such things (think [ESTree](https://github.com/estree/estree))._